### PR TITLE
added manifest.in file to include headers in python packaging

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+graft disembl/include


### PR DESCRIPTION
The header folder is not included by default in the python packaging process, so when setuptools/disttools etc creates an archive to distribute it doesn't include those files.

While it works if you clone the repo and install it, trying to add it as a dependency fails.
